### PR TITLE
support for custom JSONEncoder (eg if you have object node keys)

### DIFF
--- a/src/nx2d3/embed.py
+++ b/src/nx2d3/embed.py
@@ -1,4 +1,4 @@
-from json import dumps
+from json import dumps, JSONEncoder
 from random import sample
 
 from IPython.display import Javascript
@@ -64,7 +64,7 @@ var process_nx = function(d3, chart_id, graph, width, height) {
 """
 
 
-def embed_networkx(graph, d3_code=None, width=960, height=600):
+def embed_networkx(graph, d3_code=None, width=960, height=600, json_encoder=JSONEncoder):
     """
     Embeds a networxk into a Jupyter notebook cell with Javascript/D3
 
@@ -79,7 +79,7 @@ def embed_networkx(graph, d3_code=None, width=960, height=600):
     """
 
     d3_code = DEFAULT if d3_code is None else d3_code
-    graph = dumps(node_link_data(graph))
+    graph = dumps(node_link_data(graph), cls=json_encoder)
     chart_id = "".join(sample('abcdefghjkmopqrstuvqxyz', 16))
 
     javascript_vars = "var chart_idx='{}', graphx={}, widthx={}, heightx={};".format(chart_id, graph, width, height)


### PR DESCRIPTION
NetworkX docs basically say you can use anything as your node keys, as long as they are hashable
http://networkx.readthedocs.io/en/stable/reference/introduction.html#nodes-and-edges

I had gone down that route, with a `Node` class, but it means I need to be able to use a custom JSONEncoder on the result of `node_link_data(graph)`

I am loving the d3 graph output from this compared to built-in networkx matplotlib stuff!

(would love to be able to easily customise a few properties though, like charge and link distance)